### PR TITLE
MDL-49398 accesslib: use faster _key functions

### DIFF
--- a/lib/accesslib.php
+++ b/lib/accesslib.php
@@ -284,12 +284,13 @@ function get_role_definitions(array $roleids) {
     }
 
     // Grab all keys we have not yet got in our static cache.
-    if ($uncached = array_diff($roleids, array_keys($ACCESSLIB_PRIVATE->cacheroledefs))) {
+    $roleids = array_combine($roleids, $roleids);
+    if ($uncached = array_diff_key($roleids, $ACCESSLIB_PRIVATE->cacheroledefs)) {
         $cache = cache::make('core', 'roledefs');
         $ACCESSLIB_PRIVATE->cacheroledefs += array_filter($cache->get_many($uncached));
 
         // Check we have the remaining keys from the MUC.
-        if ($uncached = array_diff($roleids, array_keys($ACCESSLIB_PRIVATE->cacheroledefs))) {
+        if ($uncached = array_diff_key($roleids, $ACCESSLIB_PRIVATE->cacheroledefs)) {
             $uncached = get_role_definitions_uncached($uncached);
             $ACCESSLIB_PRIVATE->cacheroledefs += $uncached;
             $cache->set_many($uncached);
@@ -297,7 +298,7 @@ function get_role_definitions(array $roleids) {
     }
 
     // Return just the roles we need.
-    return array_intersect_key($ACCESSLIB_PRIVATE->cacheroledefs, array_flip($roleids));
+    return array_intersect_key($ACCESSLIB_PRIVATE->cacheroledefs, $roleids);
 }
 
 /**


### PR DESCRIPTION
Thank you for the link to the testing scripts for array_diff alternatives. For whatever reason, array_diff is crazy slow. Whether I use a foreach, array_flip, array_combine or array_diff_key, they were all about twice as fast.

This code:
* Uses array_combine so that we can easily use keys or values (negligible overhead).
* Uses array_diff_key over array_diff (twice as fast).
* Removes uses of array_keys() and array_flip() that are no longer necessary (outweighs array_combine overhead).

Please let me know what you think.